### PR TITLE
Fix for x86 compilation where perl archname contains string '64'

### DIFF
--- a/curve25519-donna-master/Makefile.PL
+++ b/curve25519-donna-master/Makefile.PL
@@ -2,8 +2,8 @@ use ExtUtils::MakeMaker;
 $Verbose = 1;
 use Config;
 
-my $extlib = $Config{archname} =~ /64/ ? 'curve25519-donna-c64' : 'curve25519-donna';
-my $extflags = $Config{archname} =~ /64/ ? '' : '-m32';
+my $extlib = $Config{archname} =~ /(?:amd64|x86_64)/ ? 'curve25519-donna-c64' : 'curve25519-donna';
+my $extflags = $Config{archname} =~ /(?:amd64|x86_64)/ ? '' : '-m32';
 
 WriteMakefile(
         NAME   => 'Crypt::Curve25519::curve25519donna',


### PR DESCRIPTION
Fix compile failure on Ubuntu 32-bit where archname=i686-linux-gnu-thread-multi-64int
